### PR TITLE
Cleanup cruft from workspace after evaluation.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,3 +15,5 @@
 # limitations under the License.
 
 /sonatype/evaluate -s $1 -a $2:$3 -i $4 -t $5 $GITHUB_WORKSPACE/$6
+# Clean up workspace
+rm -rf com.sonatype.insight.scan.outDir_IS_UNDEFINED


### PR DESCRIPTION
The policy evaluator leaves a log file in the out dir that's owned by root. This needs to be cleaned up from the workspace or subsequent runs of GitHub Actions will have trouble resetting the git repository.