### PR TITLE
fix: Fail on findings/errors

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-/sonatype/evaluate -s $1 -a $2:$3 -i $4 -t $5 $GITHUB_WORKSPACE/$6
+cleanup() {
 # Clean up workspace
 rm -rf com.sonatype.insight.scan.outDir_IS_UNDEFINED
+}
+trap cleanup EXIT
+
+/sonatype/evaluate -s $1 -a $2:$3 -i $4 -t $5 $GITHUB_WORKSPACE/$6


### PR DESCRIPTION
This patch lets the action fail on findings or other errors, such as credential errors.

Related to #4