### PR TITLE
Feat: Add pre commit linting setup/tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,67 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024 The Linux Foundation <https://linuxfoundation.org>
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-xml
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        args: ["--no-error-on-unmatched-pattern", "--ignore-unknown"]
+
+  # - repo: https://github.com/igorshubovych/markdownlint-cli
+  #   rev: v0.41.0
+  #   hooks:
+  #     - id: markdownlint
+  #       args: ["--fix"]
+
+  - repo: https://github.com/openstack/bashate
+    rev: 2.1.1
+    hooks:
+      - id: bashate
+        args: ["--ignore=E006,E011"]
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["-x"] # Check external files
+
+  - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
+    rev: v1.7.1.15
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args:
+          [
+            "-d",
+            "{rules: {line-length: {max: 120}}, ignore-from-file: [.gitignore],}",
+          ]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.5
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,14 +15,14 @@
 # limitations under the License.
 
 DEBUG_ENABLED=0
-if [[ "true" == "${7}" ]]; then
+if [ "true" = "${7}" ]; then
     DEBUG_ENABLED=1
 fi
 
 debug() {
     # $1 is message
-    if [[ $DEBUG_ENABLED == 1 ]]; then
-        echo $1
+    if [ "$DEBUG_ENABLED" = 1 ]; then
+        echo "$1"
     fi
 }
 
@@ -38,24 +38,24 @@ EVALUATE_OPTS="-s $1 -a $2:$3 -i $4 -t $5"
 TARGET="$GITHUB_WORKSPACE/$6"
 
 # If Debug Enabled, pass the flag to IQ CLI
-if [[ $DEBUG_ENABLED == 1 ]]; then
+if [ "$DEBUG_ENABLED" = 1 ]; then
     EVALUATE_OPTS="${EVALUATE_OPTS} -X"
 fi
 
 # Handle optional Proxy arguments
-if [[ ! -z "$8" ]]; then
+if [ -n "$8" ]; then
     EVALUATE_OPTS="${EVALUATE_OPTS} -p ${8}"
 fi
-if [ ! -z "$9" ]; then
+if [ -n "$9" ]; then
     EVALUATE_OPTS="${EVALUATE_OPTS} -U ${9}"
 fi
 
 # Handle $10 for -r flag
-if [[ "true" == "${10}" ]]; then
+if [ "true" = "${10}" ]; then
     EVALUATE_OPTS="${EVALUATE_OPTS} -r $GITHUB_WORKSPACE/sonatype-lifecycle-policy-eval.json"
 fi
 
 debug "EVALUATE_OPTS will be: ${EVALUATE_OPTS}"
 debug "Target will be: ${TARGET}"
 
-/sonatype/evaluate $EVALUATE_OPTS $TARGET
+/sonatype/evaluate "$EVALUATE_OPTS" "$TARGET"


### PR DESCRIPTION
The Markdown linter setup is provided "commented out". Enabling markdown linting highlights a lot of potential changes; we may not be ready to roll up our sleeves and correct those immediately?